### PR TITLE
Code.org Integration

### DIFF
--- a/client/MBFirmataClient.js
+++ b/client/MBFirmataClient.js
@@ -33,7 +33,16 @@ SOFTWARE.
  */
 
 let serialport;
-const {TextEncoder, TextDecoder} = require('util');
+let TextEncoder, TextDecoder;
+
+// If running outside of the browser, create the TextEncoder/TextDecoder
+if (typeof window === 'undefined' || !window.TextEncoder) {
+  TextEncoder = require('util').TextEncoder;
+  TextDecoder = require('util').TextDecoder;
+} else {
+  TextEncoder = window.TextEncoder;
+  TextDecoder = window.TextDecoder;
+}
 
 class MicrobitFirmataClient {
 	constructor(port) {

--- a/client/MBFirmataClient.js
+++ b/client/MBFirmataClient.js
@@ -119,10 +119,13 @@ class MicrobitFirmataClient {
 
 	// Connecting/Disconnecting
 
+  /**
+   * @returns {Promise} when port has been opened or if no port found
+   */
 	connect() {
 		// Search serial port list for a connected micro:bit and, if found, open that port.
 
-		serialport.list()
+		return serialport.list()
 		.then((ports) => {
 			for (var i = 0; i < ports.length; i++) {
 				var p = ports[i];
@@ -137,13 +140,17 @@ class MicrobitFirmataClient {
 				// Attempt to open the serial port on the given port name.
 				// If this fails it will fail with an UnhandledPromiseRejectionWarning.
 				console.log("Opening", portName);
-				this.setSerialPort(new serialport(portName, { baudRate: 57600 }));
+				return this.setSerialPort(new serialport(portName, { baudRate: 57600 }));
 			} else {
 				console.log("No micro:bit found; is your board plugged in?");
+				return null;
 			}
 		});
 	}
 
+  /**
+   * @returns {Promise} when board version is set
+   */
 	setSerialPort(port) {
 		// Use the given port. Assume the port has been opened by the caller.
 
@@ -161,7 +168,7 @@ class MicrobitFirmataClient {
 
 		// get the board serial number (used to determine board version)
 		this.boardVersion = '';
-		serialport.list()
+		return serialport.list()
 		.then((ports) => {
 			for (var i = 0; i < ports.length; i++) {
 				var p = ports[i];

--- a/client/MBFirmataClient.js
+++ b/client/MBFirmataClient.js
@@ -32,11 +32,12 @@ SOFTWARE.
  * Clients can listen for DAL events, digital pin changes, or analog channel updates.
  */
 
-const serialport = require('serialport');
+let serialport;
 const {TextEncoder, TextDecoder} = require('util');
 
 class MicrobitFirmataClient {
-	constructor() {
+	constructor(port) {
+    serialport = port ? port : require('serialport');
 		this.addConstants();
 		this.myPort = null;
 		this.inbuf = new Uint8Array(1000);


### PR DESCRIPTION
These changes facilitate the integration of the MicroBit Firmata client code into the Code.org repository: https://github.com/code-dot-org/code-dot-org.

This PR contains 3 changes:
* Allow serialport to be overridden in the constructor so that we can provide our own implementation.
* Detect when this code is run in a browser and use the global TextEncoder/Decoder in that case.
* Return a promise from `connect` and `setSerialPort` so that client code can determine when those functions are complete.

cc: @joshlory 