### PR TITLE
Update Markdown to reflect yotta registry deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Once you have verified your build toolchain works by building the `microbit-samp
 you can build the firmware as follows:
 
 	cd firmware
-	yt target bbc-microbit-classic-gcc
+	yt target bbc-microbit-classic-gcc@https://github.com/lancaster-university/yotta-target-bbc-microbit-classic-gcc
 	yt build
 
 The compiled firmware will be at:

--- a/mbFirmataFirmware.md
+++ b/mbFirmataFirmware.md
@@ -76,7 +76,7 @@ He eventually succeeded with the Yotta Windows installer on Windows 10:
 Once the Yotta toolchain is set up, compling is easy. In the Yotta terminal window type:
 
 	cd firmware
-	yt target bbc-microbit-classic-gcc
+	yt target bbc-microbit-classic-gcc@https://github.com/lancaster-university/yotta-target-bbc-microbit-classic-gcc
 	yt build
 
 The output appears in the newly created folder **build/obbc-microbit-classic-gcc/source**


### PR DESCRIPTION
Markdown has been updated to show the updated way of getting the targets from GitHub instead of the yotta registry.

These compile as intended on Windows 10 and Ubuntu 20.04.1.